### PR TITLE
 MAVLinkV2MessageRaw injection support for UDP based Mavlink connections (allowing a kind of ~Mavlink L2 routing layer).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ serde_arrays = { version = "0.1.0", optional = true }
     "minimal",
     "python_array_test",
     "standard",
+    "routing",
     "test",
     "ualberta",
     "uavionix",
@@ -93,6 +94,7 @@ serde_arrays = { version = "0.1.0", optional = true }
 "std" = ["byteorder/std"]
 "udp" = []
 "tcp" = []
+"routing" = []
 "direct-serial" = []
 "embedded" = ["embedded-hal", "nb"]
 "serde" = ["dep:serde", "dep:serde_arrays"]

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -63,7 +63,7 @@ impl MavProfile {
                         // it is a bitmask
                         if dsp == "bitmask" {
                             // find the corresponding enum
-                            for mut enm in self.enums.values_mut() {
+                            for enm in self.enums.values_mut() {
                                 if enm.name == *enum_name {
                                     // this is the right enum
                                     enm.bitfield = Some(field.mavtype.rust_primitive_type());

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -6,12 +6,19 @@ use std::io::{self};
 mod tcp;
 
 #[cfg(feature = "udp")]
+#[cfg(not(feature = "routing"))]
+mod udp;
+
+#[cfg(feature = "udp")]
+#[cfg(feature = "routing")]
 pub mod udp;
 
 #[cfg(feature = "direct-serial")]
 mod direct_serial;
 
 mod file;
+
+#[cfg(feature = "routing")]
 pub mod routing;
 
 /// A MAVLink connection

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -6,12 +6,13 @@ use std::io::{self};
 mod tcp;
 
 #[cfg(feature = "udp")]
-mod udp;
+pub mod udp;
 
 #[cfg(feature = "direct-serial")]
 mod direct_serial;
 
 mod file;
+pub mod routing;
 
 /// A MAVLink connection
 pub trait MavConnection<M: Message> {

--- a/src/connection/routing.rs
+++ b/src/connection/routing.rs
@@ -1,0 +1,60 @@
+//! Implements primitives to allow a fast routing of Mavlink messages.
+//!
+//!
+
+use crate::connection::udp::UdpConnection;
+use crate::read_v2_raw_message;
+use crate::MAVLinkV2MessageRaw;
+use crate::Message;
+use std::io;
+
+/// A RawMavConnection is a contract for a MavConnection with a
+/// couple of functions that allow a bypass of the creation/parsing of messages for fast routing
+/// between mavlink connections
+/// The Message generic is necessary as we check the message validity from its CRC which is Mavlink
+/// version dependent.
+pub trait RawMavV2Connection<M: Message> {
+    fn raw_write(&self, raw_msg: &mut MAVLinkV2MessageRaw) -> io::Result<usize>;
+    fn raw_read(&self) -> io::Result<MAVLinkV2MessageRaw>;
+}
+
+impl<M: Message> RawMavV2Connection<M> for UdpConnection {
+    fn raw_write(&self, raw_msg: &mut MAVLinkV2MessageRaw) -> io::Result<usize> {
+        let mut guard = self.writer.lock().unwrap();
+        let state = &mut *guard;
+
+        raw_msg.patch_sequence::<M>(state.sequence);
+        state.sequence = state.sequence.wrapping_add(1);
+
+        let len = if let Some(addr) = state.dest {
+            state.socket.send_to(&raw_msg.0, addr)?
+        } else {
+            0
+        };
+        Ok(len)
+    }
+
+    fn raw_read(&self) -> io::Result<MAVLinkV2MessageRaw> {
+        let mut guard = self.reader.lock().unwrap();
+        let state = &mut *guard;
+        loop {
+            if state.recv_buf.len() == 0 {
+                let (len, src) = match state.socket.recv_from(state.recv_buf.reset()) {
+                    Ok((len, src)) => (len, src),
+                    Err(error) => {
+                        return Err(error);
+                    }
+                };
+                state.recv_buf.set_len(len);
+
+                if self.server {
+                    self.writer.lock().unwrap().dest = Some(src);
+                }
+            }
+            let Ok(raw_message) = read_v2_raw_message(&mut state.recv_buf) else {continue;};
+            if raw_message.has_valid_crc::<M>() {
+                return Ok(raw_message);
+            }
+        }
+    }
+}

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -60,13 +60,13 @@ pub fn udpin<T: ToSocketAddrs>(address: T) -> io::Result<UdpConnection> {
     UdpConnection::new(socket, true, None)
 }
 
-struct UdpWrite {
-    socket: UdpSocket,
-    dest: Option<SocketAddr>,
-    sequence: u8,
+pub(crate) struct UdpWrite {
+    pub(crate) socket: UdpSocket,
+    pub(crate) dest: Option<SocketAddr>,
+    pub(crate) sequence: u8,
 }
 
-struct PacketBuf {
+pub(crate) struct PacketBuf {
     buf: Vec<u8>,
     start: usize,
     end: usize,
@@ -110,16 +110,16 @@ impl Read for PacketBuf {
     }
 }
 
-struct UdpRead {
-    socket: UdpSocket,
-    recv_buf: PacketBuf,
+pub(crate) struct UdpRead {
+    pub(crate) socket: UdpSocket,
+    pub(crate) recv_buf: PacketBuf,
 }
 
 pub struct UdpConnection {
-    reader: Mutex<UdpRead>,
-    writer: Mutex<UdpWrite>,
+    pub(crate) reader: Mutex<UdpRead>,
+    pub(crate) writer: Mutex<UdpWrite>,
     protocol_version: MavlinkVersion,
-    server: bool,
+    pub(crate) server: bool,
 }
 
 impl UdpConnection {

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -60,13 +60,13 @@ pub fn udpin<T: ToSocketAddrs>(address: T) -> io::Result<UdpConnection> {
     UdpConnection::new(socket, true, None)
 }
 
-pub(crate) struct UdpWrite {
-    pub(crate) socket: UdpSocket,
-    pub(crate) dest: Option<SocketAddr>,
-    pub(crate) sequence: u8,
+pub(super) struct UdpWrite {
+    pub(super) socket: UdpSocket,
+    pub(super) dest: Option<SocketAddr>,
+    pub(super) sequence: u8,
 }
 
-pub(crate) struct PacketBuf {
+pub(super) struct PacketBuf {
     buf: Vec<u8>,
     start: usize,
     end: usize,
@@ -110,16 +110,16 @@ impl Read for PacketBuf {
     }
 }
 
-pub(crate) struct UdpRead {
-    pub(crate) socket: UdpSocket,
-    pub(crate) recv_buf: PacketBuf,
+pub(super) struct UdpRead {
+    pub(super) socket: UdpSocket,
+    pub(super) recv_buf: PacketBuf,
 }
 
 pub struct UdpConnection {
-    pub(crate) reader: Mutex<UdpRead>,
-    pub(crate) writer: Mutex<UdpWrite>,
+    pub(super) reader: Mutex<UdpRead>,
+    pub(super) writer: Mutex<UdpWrite>,
     protocol_version: MavlinkVersion,
-    pub(crate) server: bool,
+    pub(super) server: bool,
 }
 
 impl UdpConnection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,7 +372,7 @@ const MAVLINK_IFLAG_SIGNED: u8 = 0x01;
 
 const HEADER_SIZE_V2: usize = 9;
 const SIGNATURE_SIZE_V2: usize = 13;
-pub const MAX_SIZE_V2: usize = 1 + HEADER_SIZE_V2 + 255 + 2 + SIGNATURE_SIZE_V2;
+const MAX_SIZE_V2: usize = 1 + HEADER_SIZE_V2 + 255 + 2 + SIGNATURE_SIZE_V2;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 // Follow protocol definition: `<https://mavlink.io/en/guide/serialization.html#mavlink2_packet_format>`
@@ -420,6 +420,7 @@ impl MAVLinkV2MessageRaw {
     }
 
     #[inline]
+    #[cfg(feature = "routing")]
     pub(crate) fn patch_sequence<M: Message>(&mut self, new_sequence: u8) {
         self.0[4] = new_sequence;
         self.update_crc::<M>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use std::io::{Read, Write};
 use byteorder::ReadBytesExt;
 
 #[cfg(feature = "std")]
-mod connection;
+pub mod connection;
 #[cfg(feature = "std")]
 pub use self::connection::{connect, MavConnection};
 
@@ -370,9 +370,13 @@ pub fn read_v1_msg<M: Message, R: Read>(
 
 const MAVLINK_IFLAG_SIGNED: u8 = 0x01;
 
+const HEADER_SIZE_V2: usize = 9;
+const SIGNATURE_SIZE_V2: usize = 13;
+pub const MAX_SIZE_V2: usize = 1 + HEADER_SIZE_V2 + 255 + 2 + SIGNATURE_SIZE_V2;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 // Follow protocol definition: `<https://mavlink.io/en/guide/serialization.html#mavlink2_packet_format>`
-pub struct MAVLinkV2MessageRaw([u8; 1 + Self::HEADER_SIZE + 255 + 2 + Self::SIGNATURE_SIZE]);
+pub struct MAVLinkV2MessageRaw(pub [u8; MAX_SIZE_V2]);
 
 impl Default for MAVLinkV2MessageRaw {
     fn default() -> Self {
@@ -381,21 +385,18 @@ impl Default for MAVLinkV2MessageRaw {
 }
 
 impl MAVLinkV2MessageRaw {
-    const HEADER_SIZE: usize = 9;
-    const SIGNATURE_SIZE: usize = 13;
-
     pub const fn new() -> Self {
-        Self([0; 1 + Self::HEADER_SIZE + 255 + 2 + Self::SIGNATURE_SIZE])
+        Self([0; MAX_SIZE_V2])
     }
 
     #[inline]
     pub fn header(&mut self) -> &[u8] {
-        &self.0[1..=Self::HEADER_SIZE]
+        &self.0[1..=HEADER_SIZE_V2]
     }
 
     #[inline]
     fn mut_header(&mut self) -> &mut [u8] {
-        &mut self.0[1..=Self::HEADER_SIZE]
+        &mut self.0[1..=HEADER_SIZE_V2]
     }
 
     #[inline]
@@ -419,6 +420,12 @@ impl MAVLinkV2MessageRaw {
     }
 
     #[inline]
+    pub(crate) fn patch_sequence<M: Message>(&mut self, new_sequence: u8) {
+        self.0[4] = new_sequence;
+        self.update_crc::<M>();
+    }
+
+    #[inline]
     pub fn system_id(&self) -> u8 {
         self.0[5]
     }
@@ -436,15 +443,15 @@ impl MAVLinkV2MessageRaw {
     #[inline]
     pub fn payload(&self) -> &[u8] {
         let payload_length: usize = self.payload_length().into();
-        &self.0[(1 + Self::HEADER_SIZE)..(1 + Self::HEADER_SIZE + payload_length)]
+        &self.0[(1 + HEADER_SIZE_V2)..(1 + HEADER_SIZE_V2 + payload_length)]
     }
 
     #[inline]
     pub fn checksum(&self) -> u16 {
         let payload_length: usize = self.payload_length().into();
         u16::from_le_bytes([
-            self.0[1 + Self::HEADER_SIZE + payload_length],
-            self.0[1 + Self::HEADER_SIZE + payload_length + 1],
+            self.0[1 + HEADER_SIZE_V2 + payload_length],
+            self.0[1 + HEADER_SIZE_V2 + payload_length + 1],
         ])
     }
 
@@ -453,19 +460,19 @@ impl MAVLinkV2MessageRaw {
 
         // Signature to ensure the link is tamper-proof.
         let signature_size = if (self.incompatibility_flags() & 0x01) == MAVLINK_IFLAG_SIGNED {
-            Self::SIGNATURE_SIZE
+            SIGNATURE_SIZE_V2
         } else {
             0
         };
 
         &mut self.0
-            [(1 + Self::HEADER_SIZE)..(1 + Self::HEADER_SIZE + payload_length + 2 + signature_size)]
+            [(1 + HEADER_SIZE_V2)..(1 + HEADER_SIZE_V2 + payload_length + 2 + signature_size)]
     }
 
     pub fn calculate_crc<M: Message>(&self) -> u16 {
         let payload_length: usize = self.payload_length().into();
         let mut crc_calculator = CRCu16::crc16mcrf4cc();
-        crc_calculator.digest(&self.0[1..(1 + Self::HEADER_SIZE + payload_length)]);
+        crc_calculator.digest(&self.0[1..(1 + HEADER_SIZE_V2 + payload_length)]);
 
         let extra_crc = M::extra_crc(self.message_id());
         crc_calculator.digest(&[extra_crc]);
@@ -477,12 +484,20 @@ impl MAVLinkV2MessageRaw {
         self.checksum() == self.calculate_crc::<M>()
     }
 
+    #[inline]
+    fn update_crc<M: Message>(&mut self) {
+        let payload_len: usize = self.payload_length().into();
+        let crc = self.calculate_crc::<M>();
+        self.0[(1 + HEADER_SIZE_V2 + payload_len)..(1 + HEADER_SIZE_V2 + payload_len + 2)]
+            .copy_from_slice(&crc.to_le_bytes());
+    }
+
     pub fn serialize_message<M: Message>(&mut self, header: MavHeader, message: &M) {
         self.0[0] = MAV_STX_V2;
         let msgid = message.message_id();
         let msgid_bytes = msgid.to_le_bytes();
 
-        let payload_buf = &mut self.0[(1 + Self::HEADER_SIZE)..(1 + Self::HEADER_SIZE + 255)];
+        let payload_buf = &mut self.0[(1 + HEADER_SIZE_V2)..(1 + HEADER_SIZE_V2 + 255)];
         let payload_len = message.ser(MavlinkVersion::V2, payload_buf);
 
         let header_buf = self.mut_header();
@@ -497,10 +512,7 @@ impl MAVLinkV2MessageRaw {
             msgid_bytes[1],
             msgid_bytes[2],
         ]);
-
-        let crc = self.calculate_crc::<M>();
-        self.0[(1 + Self::HEADER_SIZE + payload_len)..(1 + Self::HEADER_SIZE + payload_len + 2)]
-            .copy_from_slice(&crc.to_le_bytes());
+        self.update_crc::<M>();
     }
 }
 
@@ -574,7 +586,7 @@ pub fn write_v2_msg<M: Message, W: Write>(
     message_raw.serialize_message(header, data);
 
     let payload_length: usize = message_raw.payload_length().into();
-    let len = 1 + MAVLinkV2MessageRaw::HEADER_SIZE + payload_length + 2;
+    let len = 1 + HEADER_SIZE_V2 + payload_length + 2;
 
     w.write_all(&message_raw.0[..len])?;
 

--- a/tests/raw_udp_loopback_test.rs
+++ b/tests/raw_udp_loopback_test.rs
@@ -1,0 +1,72 @@
+mod test_shared;
+
+#[cfg(all(feature = "std", feature = "udp", feature = "common"))]
+mod test_udp_connections {
+    use crate::test_shared::get_heartbeat_msg;
+    use mavlink::common::MavMessage;
+    use mavlink::connection::routing::RawMavV2Connection;
+    use mavlink::connection::udp::{udpin, udpout};
+    use mavlink::{read_versioned_msg, MAVLinkV2MessageRaw, MavConnection, MavHeader, MAX_SIZE_V2};
+    use std::io::Cursor;
+    use std::thread;
+
+    /// Test whether we can send a raw message via UDP and receive it OK with the correct minimal
+    /// updates to it.
+    #[test]
+    pub fn test_raw_v2_udp_loopback() {
+        const RECEIVE_CHECK_COUNT: i32 = 3;
+        let server = udpin("0.0.0.0:14551").expect("Couldn't create server");
+
+        // have the client send one heartbeat per second
+        thread::spawn({
+            move || {
+                let msg = MavMessage::HEARTBEAT(get_heartbeat_msg());
+                let mut raw_msg = MAVLinkV2MessageRaw::new();
+                let header = MavHeader {
+                    system_id: 3,
+                    component_id: 2,
+                    sequence: 42, // As it will be rerouted, this sequence should be rewritted.
+                };
+                raw_msg.serialize_message(header, &msg);
+                let client = udpout("127.0.0.1:14551").expect("Couldn't create client");
+                let raw_client = &client as &dyn RawMavV2Connection<MavMessage>;
+                loop {
+                    raw_client.raw_write(&mut raw_msg).ok();
+                }
+            }
+        });
+
+        let mut recv_count = 0;
+        let mut current_sequence_number = 0u8; // it should start back at 0.
+        let raw_server = &server as &dyn RawMavV2Connection<MavMessage>;
+        for _ in 0..RECEIVE_CHECK_COUNT {
+            match raw_server.raw_read() {
+                Ok(raw_msg) => {
+                    // Check if we have a correctly patched sequence number.
+                    assert_eq!(raw_msg.sequence(), current_sequence_number);
+                    current_sequence_number += 1;
+                    // The CRC should have been patched too.
+                    assert!(raw_msg.has_valid_crc::<MavMessage>());
+                    let mut cursor = Cursor::<&[u8; MAX_SIZE_V2]>::new(&raw_msg.0);
+                    let (_hdr, msg) = read_versioned_msg::<MavMessage, Cursor<&[u8; MAX_SIZE_V2]>>(
+                        &mut cursor,
+                        (&server as &dyn MavConnection<MavMessage>).get_protocol_version(),
+                    )
+                    .unwrap();
+
+                    if let MavMessage::HEARTBEAT(_heartbeat_msg) = msg {
+                        recv_count += 1;
+                    } else {
+                        // one message parse failure fails the test
+                        break;
+                    }
+                }
+                Err(..) => {
+                    // one message read failure fails the test
+                    break;
+                }
+            }
+        }
+        assert_eq!(recv_count, RECEIVE_CHECK_COUNT);
+    }
+}


### PR DESCRIPTION
Added a read/write layer for the UDP connection to enable the injection of non parsed messages (MAVLinkV2MessageRaw) in MavLink connections  instead of only full blown parsed messages (MavMessage).