### PR TITLE
Build the target_system and target_component binary offsets 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ serde_arrays = { version = "0.1.0", optional = true }
 "direct-serial" = []
 "embedded" = ["embedded-hal", "nb"]
 "serde" = ["dep:serde", "dep:serde_arrays"]
-default = ["std", "tcp", "udp", "direct-serial", "serial", "serde", "ardupilotmega"]
+default = ["std", "tcp", "udp", "direct-serial", "serial", "serde", "routing", "ardupilotmega", "format-generated-code"]
 
 # build with all features on docs.rs so that users viewing documentation
 # can see everything

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -137,7 +137,12 @@ impl MavProfile {
             .values()
             .map(|msg| {
                 let target_offsets = msg.compute_target_offsets();
-                quote!(#target_offsets)
+                match target_offsets {
+                    (None, None) => quote!((None, None)),
+                    (None, Some(c)) => quote!((None, Some(#c))),
+                    (Some(s), None) => quote!((Some(#s), None)),
+                    (Some(s), Some(c)) => quote!((Some(#s), Some(#c))),
+                }
             })
             .collect()
     }
@@ -210,6 +215,7 @@ impl MavProfile {
                 #mav_message_id
                 #mav_message_id_from_name
                 #mav_message_default_from_id
+                #mav_target_from_message_id
                 #mav_message_serialize
                 #mav_message_crc
             }
@@ -300,8 +306,8 @@ impl MavProfile {
         target_offsets: &[TokenStream],
     ) -> TokenStream {
         quote! {
-            fn target_offsets_from_id(id: u32) -> (Option(usize), Option(usize)) {
-                match name {
+            fn target_offsets_from_id(id: u32) -> (Option<usize>, Option<usize>) {
+                match id {
                     #(#ids => #target_offsets,)*
                     _ => {
                         (None, None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ where
 
     fn message_id_from_name(name: &str) -> Result<u32, &'static str>;
     fn default_message_from_id(id: u32) -> Result<Self, &'static str>;
+    fn target_offsets_from_id(id: u32) -> (Option<usize>, Option<usize>);
     fn extra_crc(id: u32) -> u8;
 }
 

--- a/tests/target_decode_tests.rs
+++ b/tests/target_decode_tests.rs
@@ -1,0 +1,68 @@
+#[cfg(test)]
+mod tests {
+    use mavlink::ardupilotmega::MavMessage;
+    use mavlink::ardupilotmega::CHANGE_OPERATOR_CONTROL_DATA;
+    use mavlink::ardupilotmega::DEBUG_DATA;
+    use mavlink::ardupilotmega::PING_DATA;
+    use mavlink::MavlinkVersion;
+    use mavlink::Message;
+    #[test]
+    fn test_ping_target_ids() {
+        let msg = MavMessage::PING(PING_DATA {
+            time_usec: 0,
+            seq: 0,
+            target_system: 3,
+            target_component: 14,
+        });
+        let mut buffer: [u8; 300] = [0; 300];
+
+        msg.ser(MavlinkVersion::V2, &mut buffer);
+        let (target_system_id_offset, target_component_id_offset) =
+            MavMessage::target_offsets_from_id(msg.message_id());
+        assert_eq!(
+            buffer[target_system_id_offset
+                .expect("There should be a target_system_id_offset on this message.")],
+            3
+        );
+        assert_eq!(
+            buffer[target_component_id_offset
+                .expect("There should be a target_component_id_offset on this message.")],
+            14
+        );
+    }
+
+    #[test]
+    fn test_no_target_ids() {
+        let msg = MavMessage::DEBUG(DEBUG_DATA {
+            time_boot_ms: 0,
+            value: 0.0,
+            ind: 0,
+        });
+        let mut buffer: [u8; 300] = [0; 300];
+
+        msg.ser(MavlinkVersion::V2, &mut buffer);
+        let (target_system_id_offset, target_component_id_offset) =
+            MavMessage::target_offsets_from_id(msg.message_id());
+
+        assert!(target_component_id_offset.is_none());
+        assert!(target_system_id_offset.is_none());
+    }
+
+    #[test]
+    fn test_just_one_target_ids() {
+        let msg = MavMessage::CHANGE_OPERATOR_CONTROL(CHANGE_OPERATOR_CONTROL_DATA {
+            target_system: 122,
+            control_request: 0,
+            version: 0,
+            passkey: [0; 25],
+        });
+        let mut buffer: [u8; 300] = [0; 300];
+
+        msg.ser(MavlinkVersion::V2, &mut buffer);
+        let (target_system_id_offset, target_component_id_offset) =
+            MavMessage::target_offsets_from_id(msg.message_id());
+
+        assert!(target_component_id_offset.is_none());
+        assert_eq!(buffer[target_system_id_offset.unwrap()], 122);
+    }
+}


### PR DESCRIPTION
Mavlink has only a selected set of messages with target_system and target_component that enable a smarter routing than just broadcasting everything.

This PR generated the index for the messages to their potential offsets for those 2 parameters.