### PR TITLE
Implemented a full duplex access to the  Serial port.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,13 @@ crc-any = { version = "2.3.5", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-derive = "0.3.2"
 bitflags = "1.2.1"
-serial = { version = "0.4", optional = true }
+serialport = { version = "4.2.2", optional = true}
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 byteorder = { version = "1.3.4", default-features = false }
 embedded-hal = { version = "0.2", optional = true }
 nb = { version = "1.0", optional = true }
 serde_arrays = { version = "0.1.0", optional = true }
+log = "*"
 
 [features]
 "all" = [
@@ -95,10 +96,10 @@ serde_arrays = { version = "0.1.0", optional = true }
 "udp" = []
 "tcp" = []
 "routing" = []
-"direct-serial" = []
+"serial" = ["serialport"]
 "embedded" = ["embedded-hal", "nb"]
 "serde" = ["dep:serde", "dep:serde_arrays"]
-default = ["std", "tcp", "udp", "direct-serial", "serial", "serde", "routing", "ardupilotmega", "format-generated-code"]
+default = ["std", "tcp", "udp", "serial", "serde", "routing", "ardupilotmega", "format-generated-code"]
 
 # build with all features on docs.rs so that users viewing documentation
 # can see everything

--- a/src/connection/direct_serial.rs
+++ b/src/connection/direct_serial.rs
@@ -27,7 +27,7 @@ pub fn open(settings: &str) -> io::Result<SerialConnection> {
 
     let baud = serial::core::BaudRate::from_speed(baud_opt.unwrap());
 
-    let settings = serial::core::PortSettings {
+    let port_settings = serial::core::PortSettings {
         baud_rate: baud,
         char_size: serial::Bits8,
         parity: serial::ParityNone,
@@ -37,12 +37,13 @@ pub fn open(settings: &str) -> io::Result<SerialConnection> {
 
     let port_name = settings_toks[0];
     let mut port = serial::open(port_name)?;
-    port.configure(&settings)?;
+    port.configure(&port_settings)?;
 
     Ok(SerialConnection {
         port: Mutex::new(port),
         sequence: Mutex::new(0),
         protocol_version: MavlinkVersion::V2,
+        id: settings.to_string(),
     })
 }
 
@@ -50,6 +51,7 @@ pub struct SerialConnection {
     pub(crate) port: Mutex<serial::SystemPort>,
     pub(crate) sequence: Mutex<u8>,
     pub(crate) protocol_version: MavlinkVersion,
+    pub(crate) id: String,
 }
 
 impl<M: Message> MavConnection<M> for SerialConnection {

--- a/src/connection/direct_serial.rs
+++ b/src/connection/direct_serial.rs
@@ -5,6 +5,7 @@ use serialport;
 use serialport::{DataBits, FlowControl, Parity, SerialPort, StopBits};
 use std::io;
 use std::sync::Mutex;
+use std::time::Duration;
 
 /// Serial MAVLINK connection
 
@@ -31,7 +32,8 @@ pub fn open(settings: &str) -> io::Result<SerialConnection> {
         .data_bits(DataBits::Eight)
         .parity(Parity::None)
         .stop_bits(StopBits::One)
-        .flow_control(FlowControl::None);
+        .flow_control(FlowControl::None)
+        .timeout(Duration::from_secs(1));
 
     let reader_side = port_builder.open()?;
     let writer_side = reader_side

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -13,7 +13,7 @@ pub mod udp;
 #[cfg(feature = "routing")]
 pub mod udp;
 
-#[cfg(feature = "direct-serial")]
+#[cfg(feature = "serial")]
 pub mod direct_serial;
 
 mod file;
@@ -95,12 +95,12 @@ pub fn connect<M: Message>(address: &str) -> io::Result<Box<dyn MavConnection<M>
         {
             protocol_err
         }
-    } else if cfg!(feature = "direct-serial") && address.starts_with("serial:") {
-        #[cfg(feature = "direct-serial")]
+    } else if cfg!(feature = "serial") && address.starts_with("serial:") {
+        #[cfg(feature = "serial")]
         {
             Ok(Box::new(direct_serial::open(&address["serial:".len()..])?))
         }
-        #[cfg(not(feature = "direct-serial"))]
+        #[cfg(not(feature = "serial"))]
         {
             protocol_err
         }

--- a/src/connection/routing.rs
+++ b/src/connection/routing.rs
@@ -25,54 +25,54 @@ impl CommonMessageRaw for MAVLinkMessageRaw {
     #[inline]
     fn message_id(&self) -> u32 {
         match self {
-            MAVLinkMessageRaw::V1(m) => m.message_id(),
-            MAVLinkMessageRaw::V2(m) => m.message_id(),
+            Self::V1(m) => m.message_id(),
+            Self::V2(m) => m.message_id(),
         }
     }
 
     #[inline]
     fn system_id(&self) -> u8 {
         match self {
-            MAVLinkMessageRaw::V1(m) => m.system_id(),
-            MAVLinkMessageRaw::V2(m) => m.system_id(),
+            Self::V1(m) => m.system_id(),
+            Self::V2(m) => m.system_id(),
         }
     }
 
     #[inline]
     fn component_id(&self) -> u8 {
         match self {
-            MAVLinkMessageRaw::V1(m) => m.component_id(),
-            MAVLinkMessageRaw::V2(m) => m.component_id(),
+            Self::V1(m) => m.component_id(),
+            Self::V2(m) => m.component_id(),
         }
     }
 
     #[inline]
     fn len(&self) -> usize {
         match self {
-            MAVLinkMessageRaw::V1(m) => m.len(),
-            MAVLinkMessageRaw::V2(m) => m.len(),
+            Self::V1(m) => m.len(),
+            Self::V2(m) => m.len(),
         }
     }
 
     #[inline]
     fn full(&self) -> &[u8] {
         match self {
-            MAVLinkMessageRaw::V1(m) => m.full(),
-            MAVLinkMessageRaw::V2(m) => m.full(),
+            Self::V1(m) => m.full(),
+            Self::V2(m) => m.full(),
         }
     }
 
     fn payload_length(&self) -> usize {
         match self {
-            MAVLinkMessageRaw::V1(m) => m.payload_length().into(),
-            MAVLinkMessageRaw::V2(m) => m.payload_length().into(),
+            Self::V1(m) => m.payload_length(),
+            Self::V2(m) => m.payload_length(),
         }
     }
 
     fn payload(&self) -> &[u8] {
         match self {
-            MAVLinkMessageRaw::V1(m) => m.payload(),
-            MAVLinkMessageRaw::V2(m) => m.payload(),
+            Self::V1(m) => m.payload(),
+            Self::V2(m) => m.payload(),
         }
     }
 }
@@ -97,7 +97,7 @@ impl<M: Message> RawConnection<M> for UdpConnection {
         state.sequence = state.sequence.wrapping_add(1);
 
         let len = if let Some(addr) = state.dest {
-            state.socket.send_to(&msg.full(), addr)?
+            state.socket.send_to(msg.full(), addr)?
         } else {
             0
         };
@@ -157,7 +157,7 @@ impl<M: Message> RawConnection<M> for SerialConnection {
         //let mut sequence = self.sequence.lock().unwrap();
         //raw_msg.patch_sequence::<M>(*sequence);
         //*sequence = sequence.wrapping_add(1);
-        match (&mut *port).write_all(msg.full()) {
+        match (*port).write_all(msg.full()) {
             Ok(_) => Ok(msg.len()),
             Err(e) => Err(e),
         }

--- a/src/connection/routing.rs
+++ b/src/connection/routing.rs
@@ -157,7 +157,7 @@ impl<M: Message> RawConnection<M> for SerialConnection {
     fn raw_write(&self, msg: &mut dyn CommonMessageRaw) -> io::Result<usize> {
         let mut port = self.writer.lock().unwrap();
         let bf = std::time::Instant::now();
-        let res = match (&mut *port).write_all(msg.full()) {
+        let res = match (*port).write_all(msg.full()) {
             Ok(_) => Ok(msg.len()),
             Err(e) => Err(e),
         };

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -37,7 +37,7 @@ pub fn udpbcast<T: ToSocketAddrs>(address: T) -> io::Result<UdpConnection> {
     socket
         .set_broadcast(true)
         .expect("Couldn't bind to broadcast address.");
-    UdpConnection::new(socket, false, Some(addr))
+    UdpConnection::new(socket, false, Some(addr), addr.to_string().as_str())
 }
 
 pub fn udpout<T: ToSocketAddrs>(address: T) -> io::Result<UdpConnection> {
@@ -47,7 +47,7 @@ pub fn udpout<T: ToSocketAddrs>(address: T) -> io::Result<UdpConnection> {
         .next()
         .expect("Invalid address");
     let socket = UdpSocket::bind("0.0.0.0:0")?;
-    UdpConnection::new(socket, false, Some(addr))
+    UdpConnection::new(socket, false, Some(addr), addr.to_string().as_str())
 }
 
 pub fn udpin<T: ToSocketAddrs>(address: T) -> io::Result<UdpConnection> {
@@ -57,7 +57,7 @@ pub fn udpin<T: ToSocketAddrs>(address: T) -> io::Result<UdpConnection> {
         .next()
         .expect("Invalid address");
     let socket = UdpSocket::bind(addr)?;
-    UdpConnection::new(socket, true, None)
+    UdpConnection::new(socket, true, None, addr.to_string().as_str())
 }
 
 pub(super) struct UdpWrite {
@@ -120,10 +120,16 @@ pub struct UdpConnection {
     pub(super) writer: Mutex<UdpWrite>,
     protocol_version: MavlinkVersion,
     pub(super) server: bool,
+    pub(super) id: String,
 }
 
 impl UdpConnection {
-    fn new(socket: UdpSocket, server: bool, dest: Option<SocketAddr>) -> io::Result<Self> {
+    fn new(
+        socket: UdpSocket,
+        server: bool,
+        dest: Option<SocketAddr>,
+        id: &str,
+    ) -> io::Result<Self> {
         Ok(Self {
             server,
             reader: Mutex::new(UdpRead {
@@ -136,6 +142,7 @@ impl UdpConnection {
                 sequence: 0,
             }),
             protocol_version: MavlinkVersion::V2,
+            id: id.to_string(),
         })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use core::fmt::{Display, Formatter};
+
 #[cfg(feature = "std")]
 use std::error::Error;
 
@@ -35,6 +36,10 @@ pub enum MessageReadError {
     #[cfg(feature = "embedded")]
     Io,
     Parse(ParserError),
+    InvalidCRC {
+        expected: u16,
+        got: u16,
+    },
 }
 
 impl Display for MessageReadError {
@@ -45,6 +50,12 @@ impl Display for MessageReadError {
             #[cfg(feature = "embedded")]
             Self::Io => write!(f, "Failed to read message"),
             Self::Parse(e) => write!(f, "Failed to read message: {e:#?}"),
+            Self::InvalidCRC { expected, got } => write!(
+                f,
+                "Invalid CRC, expected {expected:#?}, got {got:#?}",
+                expected = expected,
+                got = got
+            ),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,7 @@ pub fn read_versioned_msg<M: Message, R: Read>(
 pub struct MAVLinkAnyMessageRaw<const S: usize>([u8; S]);
 
 /// This extracts all the common useful fields from a MAVLink message be a V1 or V2
+#[allow(clippy::len_without_is_empty)]
 pub trait CommonMessageRaw {
     fn message_id(&self) -> u32;
     fn system_id(&self) -> u8;
@@ -229,10 +230,6 @@ pub type MAVLinkV1MessageRaw = MAVLinkAnyMessageRaw<MAX_SIZE_V1>;
 
 const HEADER_SIZE_V1: usize = 5;
 pub const MAX_SIZE_V1: usize = 1 + HEADER_SIZE_V1 + 255 + 2;
-
-//#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-// Follow protocol definition: `<https://mavlink.io/en/guide/serialization.html#v1_packet_format>`
-//pub struct MAVLinkV1MessageRaw([u8; MAX_SIZE_V1]);
 
 impl Default for MAVLinkV1MessageRaw {
     fn default() -> Self {
@@ -258,8 +255,7 @@ impl CommonMessageRaw for MAVLinkV1MessageRaw {
 
     #[inline]
     fn len(&self) -> usize {
-        let payload_length: usize = self.payload_length().into();
-        1 + HEADER_SIZE_V1 + payload_length
+        1 + HEADER_SIZE_V1 + self.payload_length()
     }
 
     #[inline]
@@ -269,8 +265,7 @@ impl CommonMessageRaw for MAVLinkV1MessageRaw {
 
     #[inline]
     fn payload(&self) -> &[u8] {
-        let payload_length: usize = self.payload_length().into();
-        &self.0[(1 + HEADER_SIZE_V1)..(1 + HEADER_SIZE_V1 + payload_length)]
+        &self.0[(1 + HEADER_SIZE_V1)..(1 + HEADER_SIZE_V1 + self.payload_length())]
     }
 
     #[inline]
@@ -301,7 +296,7 @@ impl MAVLinkV1MessageRaw {
 
     #[inline]
     pub fn checksum(&self) -> u16 {
-        let payload_length: usize = self.payload_length().into();
+        let payload_length = self.payload_length();
         u16::from_le_bytes([
             self.0[1 + HEADER_SIZE_V1 + payload_length],
             self.0[1 + HEADER_SIZE_V1 + payload_length + 1],
@@ -310,15 +305,14 @@ impl MAVLinkV1MessageRaw {
 
     #[inline]
     fn mut_payload_and_checksum(&mut self) -> &mut [u8] {
-        let payload_length: usize = self.payload_length().into();
+        let payload_length = self.payload_length();
         &mut self.0[(1 + HEADER_SIZE_V1)..(1 + HEADER_SIZE_V1 + payload_length + 2)]
     }
 
     pub fn calculate_crc<M: Message>(&self) -> u16 {
-        let payload_length: usize = self.payload_length().into();
         let mut crc_calculator = CRCu16::crc16mcrf4cc();
-        crc_calculator.digest(&self.0[1..(1 + HEADER_SIZE_V1 + payload_length)]);
-        let extra_crc = M::extra_crc(self.message_id().into());
+        crc_calculator.digest(&self.0[1..(1 + HEADER_SIZE_V1 + self.payload_length())]);
+        let extra_crc = M::extra_crc(self.message_id());
 
         crc_calculator.digest(&[extra_crc]);
         crc_calculator.get_crc()
@@ -382,22 +376,18 @@ pub fn read_v1_msg<M: Message, R: Read>(
             continue;
         }
 
-        return M::parse(
-            MavlinkVersion::V1,
-            u32::from(message.message_id()),
-            message.payload(),
-        )
-        .map(|msg| {
-            (
-                MavHeader {
-                    sequence: message.sequence(),
-                    system_id: message.system_id(),
-                    component_id: message.component_id(),
-                },
-                msg,
-            )
-        })
-        .map_err(|err| err.into());
+        return M::parse(MavlinkVersion::V1, message.message_id(), message.payload())
+            .map(|msg| {
+                (
+                    MavHeader {
+                        sequence: message.sequence(),
+                        system_id: message.system_id(),
+                        component_id: message.component_id(),
+                    },
+                    msg,
+                )
+            })
+            .map_err(|err| err.into());
     }
 }
 
@@ -428,7 +418,7 @@ impl CommonMessageRaw for MAVLinkV2MessageRaw {
 
     #[inline]
     fn len(&self) -> usize {
-        let payload_length: usize = self.payload_length().into();
+        let payload_length = self.payload_length();
 
         let signature_size = if (self.incompatibility_flags() & 0x01) == MAVLINK_IFLAG_SIGNED {
             SIGNATURE_SIZE_V2
@@ -450,7 +440,7 @@ impl CommonMessageRaw for MAVLinkV2MessageRaw {
 
     #[inline]
     fn payload(&self) -> &[u8] {
-        let payload_length: usize = self.payload_length().into();
+        let payload_length = self.payload_length();
         &self.0[(1 + HEADER_SIZE_V2)..(1 + HEADER_SIZE_V2 + payload_length)]
     }
 }
@@ -495,7 +485,7 @@ impl MAVLinkV2MessageRaw {
 
     #[inline]
     pub fn checksum(&self) -> u16 {
-        let payload_length: usize = self.payload_length().into();
+        let payload_length = self.payload_length();
         u16::from_le_bytes([
             self.0[1 + HEADER_SIZE_V2 + payload_length],
             self.0[1 + HEADER_SIZE_V2 + payload_length + 1],
@@ -508,7 +498,7 @@ impl MAVLinkV2MessageRaw {
     }
 
     pub fn calculate_crc<M: Message>(&self) -> u16 {
-        let payload_length: usize = self.payload_length().into();
+        let payload_length = self.payload_length();
         let mut crc_calculator = CRCu16::crc16mcrf4cc();
         crc_calculator.digest(&self.0[1..(1 + HEADER_SIZE_V2 + payload_length)]);
 
@@ -524,7 +514,7 @@ impl MAVLinkV2MessageRaw {
 
     #[inline]
     fn update_crc<M: Message>(&mut self) {
-        let payload_len: usize = self.payload_length().into();
+        let payload_len = self.payload_length();
         let crc = self.calculate_crc::<M>();
         self.0[(1 + HEADER_SIZE_V2 + payload_len)..(1 + HEADER_SIZE_V2 + payload_len + 2)]
             .copy_from_slice(&crc.to_le_bytes());
@@ -669,7 +659,7 @@ pub fn write_v2_msg<M: Message, W: Write>(
     let mut message_raw = MAVLinkV2MessageRaw::new();
     message_raw.serialize_message(header, data);
 
-    let payload_length: usize = message_raw.payload_length().into();
+    let payload_length = message_raw.payload_length();
     let len = 1 + HEADER_SIZE_V2 + payload_length + 2;
 
     w.write_all(&message_raw.0[..len])?;
@@ -686,7 +676,7 @@ pub fn write_v1_msg<M: Message, W: Write>(
     let mut message_raw = MAVLinkV1MessageRaw::new();
     message_raw.serialize_message(header, data);
 
-    let payload_length: usize = message_raw.payload_length().into();
+    let payload_length = message_raw.payload_length();
     let len = 1 + HEADER_SIZE_V1 + payload_length + 2;
 
     w.write_all(&message_raw.0[..len])?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,7 +544,7 @@ impl MAVLinkV2MessageRaw {
     }
 }
 
-pub fn read_raw_message<R: Read, M: Message>(
+pub fn read_raw_message<R: Read + ?Sized, M: Message>(
     reader: &mut R,
 ) -> Result<MAVLinkMessageRaw, error::MessageReadError> {
     loop {

--- a/tests/direct_serial_tests.rs
+++ b/tests/direct_serial_tests.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "std", feature = "direct-serial", feature = "common"))]
+#[cfg(all(feature = "std", feature = "serial", feature = "common"))]
 mod test_direct_serial {
     use mavlink::common::MavMessage;
 


### PR DESCRIPTION
The original rust-mavlink has a contention issue if you try to read and write at the same time to the serial port.
I just switched to another serial support crate called serialport that allows to clone the Reader + Writer to allow a full duplex access.

The ultimate implementation would be with tokio + mio + async but this seems to work good enough for what we want to do with it.