### PR TITLE
Added a way to extend the original mavlink msg set.

### DIFF
--- a/build/extra_messages/skyways.xml
+++ b/build/extra_messages/skyways.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<mavlink>
+  <include>ardupilotmega.xml</include>
+  <dialect>2</dialect>
+  <enums>
+    <enum name="SKYWAYS_ROCKS">
+      <entry value="1" name="A_LITTLE"/>
+      <entry value="2" name="A_LOT"/>
+    </enum>
+  </enums>
+  <messages>
+    <message id="31415" name="AWESOME_MSG">
+      <description>Some test message</description>
+      <field type="float" name="answer">answer.</field>
+    </message>
+  </messages>
+</mavlink>

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -1126,6 +1126,7 @@ fn is_valid_parent(p: Option<MavXmlElement>, s: MavXmlElement) -> bool {
 }
 
 pub fn parse_profile(
+    base_dir: &Path,
     definitions_dir: &Path,
     definition_file: &String,
     parsed_files: &mut HashSet<PathBuf>,
@@ -1424,10 +1425,10 @@ pub fn parse_profile(
                         profile.add_enum(&mavenum);
                     }
                     Some(&MavXmlElement::Include) => {
-                        let include_file = Path::new(&definitions_dir).join(include.clone());
+                        let include_file = Path::new(&base_dir).join(include.clone());
                         if !parsed_files.contains(&include_file) {
                             let included_profile =
-                                parse_profile(definitions_dir, &include, parsed_files);
+                                parse_profile(&base_dir, &base_dir, &include, parsed_files);
                             for message in included_profile.messages.values() {
                                 profile.add_message(message);
                             }
@@ -1455,9 +1456,19 @@ pub fn parse_profile(
 
 /// Generate protobuf represenation of mavlink message set
 /// Generate rust representation of mavlink message set with appropriate conversion methods
-pub fn generate<W: Write>(definitions_dir: &Path, definition_file: &String, output_rust: &mut W) {
+pub fn generate<W: Write>(
+    base_dir: &Path,
+    definitions_dir: &Path,
+    definition_file: &String,
+    output_rust: &mut W,
+) {
     let mut parsed_files: HashSet<PathBuf> = HashSet::new();
-    let profile = parse_profile(definitions_dir, definition_file, &mut parsed_files);
+    let profile = parse_profile(
+        base_dir,
+        definitions_dir,
+        definition_file,
+        &mut parsed_files,
+    );
 
     // rust file
     let rust_tokens = profile.emit_rust();


### PR DESCRIPTION
This is done by reserving build/extra_messages for a set of xml to add to the general generation loop.