### PR TITLE
Adds new UDP connection type that supports connection multiplexing (e.g. udpins:host:port[:max])

### DIFF
--- a/src/connection/routing.rs
+++ b/src/connection/routing.rs
@@ -3,7 +3,7 @@
 //!
 use crate::connection::direct_serial::SerialConnection;
 use crate::connection::tcp::TcpConnection;
-use crate::connection::udp::UdpConnection;
+use crate::connection::udp::{UdpConnection, UdpMultiConnection};
 use crate::read_raw_message;
 use crate::read_v1_raw_message;
 use crate::read_v2_raw_message;
@@ -341,5 +341,63 @@ impl<M: Message> RawConnection<M> for TcpConnection {
 
     fn connection_id(&self) -> String {
         self.id.clone() //FIXME(gbin)
+    }
+}
+
+impl<M: Message> RawConnection<M> for UdpMultiConnection {
+    fn raw_write(&self, msg: &mut MAVLinkMessageRaw) -> io::Result<usize> {
+        let mut guard = self.writer.lock().unwrap();
+        let state = &mut *guard;
+        state.sequence = state.sequence.wrapping_add(1);
+        Ok(state
+            .dests
+            .iter()
+            .filter_map(|&a| state.socket.send_to(msg.full(), a).ok())
+            .sum())
+    }
+
+    fn raw_read(&self) -> io::Result<MAVLinkMessageRaw> {
+        let mut guard = self.reader.lock().unwrap();
+        let state = &mut *guard;
+        loop {
+            if state.recv_buf.len() == 0 {
+                let (len, src) = state.socket.recv_from(state.recv_buf.reset())?;
+                state.recv_buf.set_len(len);
+                let mut w = self.writer.lock().unwrap();
+                if !w.dests.contains(&src) {
+                    if w.dests.len() >= w.max_clients {
+                        w.dests.remove(0);
+                    }
+                    w.dests.push(src);
+                }
+            }
+            if state.recv_buf.len() == 0 {
+                continue;
+            }
+            if state.recv_buf.slice()[0] == crate::MAV_STX {
+                let Ok(msg) = read_v1_raw_message(&mut state.recv_buf) else {
+                    warn!("Error parsing a v1 Message.");
+                    continue;
+                };
+                return Ok(MAVLinkMessageRaw::V1(msg));
+            }
+            if state.recv_buf.slice()[0] != crate::MAV_STX_V2 {
+                state.recv_buf.reset();
+                continue;
+            }
+            let Ok(msg) = read_v2_raw_message(&mut state.recv_buf) else {
+                warn!("Error parsing a v2 Message.");
+                continue;
+            };
+            if !msg.has_valid_crc::<M>() {
+                warn!("Invalid CRC: msg={:?}.", msg);
+                continue;
+            }
+            return Ok(MAVLinkMessageRaw::V2(msg));
+        }
+    }
+
+    fn connection_id(&self) -> String {
+        self.id.clone()
     }
 }

--- a/src/connection/routing.rs
+++ b/src/connection/routing.rs
@@ -346,10 +346,18 @@ impl<M: Message> RawConnection<M> for TcpConnection {
 
 impl<M: Message> RawConnection<M> for UdpMultiConnection {
     fn raw_write(&self, msg: &mut MAVLinkMessageRaw) -> io::Result<usize> {
-        let guard = self.writer.lock().unwrap();
-        for &addr in guard.dests.iter() {
-            let _ = guard.socket.send_to(msg.full(), addr);
+        let mut guard = self.writer.lock().unwrap();
+        let state = &mut *guard;
+        let bf = std::time::Instant::now();
+        state.sequence = state.sequence.wrapping_add(1);
+
+        for &addr in state.dests.iter() {
+            let _ = state.socket.send_to(msg.full(), addr);
         }
+        if bf.elapsed().as_millis() > 100 {
+            debug!("Took too long to write UDP: {}ms", bf.elapsed().as_millis());
+        }
+
         Ok(msg.len())
     }
 
@@ -358,8 +366,14 @@ impl<M: Message> RawConnection<M> for UdpMultiConnection {
         let state = &mut *guard;
         loop {
             if state.recv_buf.len() == 0 {
-                let (len, src) = state.socket.recv_from(state.recv_buf.reset())?;
+                let (len, src) = match state.socket.recv_from(state.recv_buf.reset()) {
+                    Ok((len, src)) => (len, src),
+                    Err(error) => {
+                        return Err(error);
+                    }
+                };
                 state.recv_buf.set_len(len);
+
                 let mut w = self.writer.lock().unwrap();
                 if !w.dests.contains(&src) {
                     if w.dests.len() >= w.max_clients {
@@ -368,6 +382,7 @@ impl<M: Message> RawConnection<M> for UdpMultiConnection {
                     w.dests.push(src);
                 }
             }
+            // Skip empty packets (valid in UDP but not MAVLink)
             if state.recv_buf.len() == 0 {
                 continue;
             }
@@ -377,20 +392,21 @@ impl<M: Message> RawConnection<M> for UdpMultiConnection {
                     continue;
                 };
                 return Ok(MAVLinkMessageRaw::V1(msg));
+            } else {
+                if state.recv_buf.slice()[0] != crate::MAV_STX_V2 {
+                    state.recv_buf.reset();
+                    continue;
+                }
+                let Ok(msg) = read_v2_raw_message(&mut state.recv_buf) else {
+                    warn!("Error parsing a v2 Message.");
+                    continue;
+                };
+                if !msg.has_valid_crc::<M>() {
+                    warn!("Invalid CRC: msg={:?}.", msg);
+                    continue;
+                }
+                return Ok(MAVLinkMessageRaw::V2(msg));
             }
-            if state.recv_buf.slice()[0] != crate::MAV_STX_V2 {
-                state.recv_buf.reset();
-                continue;
-            }
-            let Ok(msg) = read_v2_raw_message(&mut state.recv_buf) else {
-                warn!("Error parsing a v2 Message.");
-                continue;
-            };
-            if !msg.has_valid_crc::<M>() {
-                warn!("Invalid CRC: msg={:?}.", msg);
-                continue;
-            }
-            return Ok(MAVLinkMessageRaw::V2(msg));
         }
     }
 

--- a/src/connection/routing.rs
+++ b/src/connection/routing.rs
@@ -346,14 +346,11 @@ impl<M: Message> RawConnection<M> for TcpConnection {
 
 impl<M: Message> RawConnection<M> for UdpMultiConnection {
     fn raw_write(&self, msg: &mut MAVLinkMessageRaw) -> io::Result<usize> {
-        let mut guard = self.writer.lock().unwrap();
-        let state = &mut *guard;
-        state.sequence = state.sequence.wrapping_add(1);
-        Ok(state
-            .dests
-            .iter()
-            .filter_map(|&a| state.socket.send_to(msg.full(), a).ok())
-            .sum())
+        let guard = self.writer.lock().unwrap();
+        for &addr in guard.dests.iter() {
+            let _ = guard.socket.send_to(msg.full(), addr);
+        }
+        Ok(msg.len())
     }
 
     fn raw_read(&self) -> io::Result<MAVLinkMessageRaw> {
@@ -366,7 +363,7 @@ impl<M: Message> RawConnection<M> for UdpMultiConnection {
                 let mut w = self.writer.lock().unwrap();
                 if !w.dests.contains(&src) {
                     if w.dests.len() >= w.max_clients {
-                        w.dests.remove(0);
+                        w.dests.swap_remove(0);
                     }
                     w.dests.push(src);
                 }

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -222,13 +222,61 @@ impl UdpMultiConnection {
             }),
             writer: Mutex::new(UdpMultiWrite {
                 socket,
-                dests: Vec::with_capacity(max_clients.min(64)),
+                dests: Vec::with_capacity(max_clients),
                 max_clients,
                 sequence: 0,
             }),
             protocol_version: MavlinkVersion::V2,
             id: id.to_string(),
         })
+    }
+}
+
+impl<M: Message> MavConnection<M> for UdpMultiConnection {
+    fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {
+        let mut guard = self.reader.lock().unwrap();
+        let state = &mut *guard;
+        loop {
+            if state.recv_buf.len() == 0 {
+                let (len, src) = state.socket.recv_from(state.recv_buf.reset())?;
+                state.recv_buf.set_len(len);
+                let mut w = self.writer.lock().unwrap();
+                if !w.dests.contains(&src) {
+                    if w.dests.len() >= w.max_clients {
+                        w.dests.swap_remove(0);
+                    }
+                    w.dests.push(src);
+                }
+            }
+            if let ok @ Ok(..) = read_versioned_msg(&mut state.recv_buf, self.protocol_version) {
+                return ok;
+            }
+        }
+    }
+
+    fn send(&self, header: &MavHeader, data: &M) -> Result<usize, crate::error::MessageWriteError> {
+        let mut guard = self.writer.lock().unwrap();
+        let state = &mut *guard;
+        let header = MavHeader {
+            sequence: state.sequence,
+            system_id: header.system_id,
+            component_id: header.component_id,
+        };
+        state.sequence = state.sequence.wrapping_add(1);
+        let mut buf = Vec::new();
+        write_versioned_msg(&mut buf, self.protocol_version, header, data)?;
+        for &addr in state.dests.iter() {
+            let _ = state.socket.send_to(&buf, addr);
+        }
+        Ok(buf.len())
+    }
+
+    fn set_protocol_version(&mut self, version: MavlinkVersion) {
+        self.protocol_version = version;
+    }
+
+    fn get_protocol_version(&self) -> MavlinkVersion {
+        self.protocol_version
     }
 }
 
@@ -240,7 +288,7 @@ pub fn udpins(address: &str) -> io::Result<UdpMultiConnection> {
     let addr = addr_str
         .to_socket_addrs()?
         .next()
-        .expect("udpins: invalid address");
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "udpins: invalid address"))?;
     let socket = UdpSocket::bind(addr)?;
     UdpMultiConnection::new(socket, &format!("udpins:{}", address), max_clients)
 }

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -6,6 +6,8 @@ use std::net::ToSocketAddrs;
 use std::net::{SocketAddr, UdpSocket};
 use std::sync::Mutex;
 
+const DEFAULT_MAX_CLIENTS: usize = 64;
+
 /// UDP MAVLink connection
 
 pub fn select_protocol<M: Message>(address: &str) -> io::Result<Box<dyn MavConnection<M>>> {
@@ -195,4 +197,50 @@ impl<M: Message> MavConnection<M> for UdpConnection {
     fn get_protocol_version(&self) -> MavlinkVersion {
         self.protocol_version
     }
+}
+
+pub(super) struct UdpMultiWrite {
+    pub(super) socket: UdpSocket,
+    pub(super) dests: Vec<SocketAddr>,
+    pub(super) max_clients: usize,
+    pub(super) sequence: u8,
+}
+
+pub struct UdpMultiConnection {
+    pub(super) reader: Mutex<UdpRead>,
+    pub(super) writer: Mutex<UdpMultiWrite>,
+    protocol_version: MavlinkVersion,
+    pub(super) id: String,
+}
+
+impl UdpMultiConnection {
+    pub fn new(socket: UdpSocket, id: &str, max_clients: usize) -> io::Result<Self> {
+        Ok(Self {
+            reader: Mutex::new(UdpRead {
+                socket: socket.try_clone()?,
+                recv_buf: PacketBuf::new(),
+            }),
+            writer: Mutex::new(UdpMultiWrite {
+                socket,
+                dests: Vec::with_capacity(max_clients.min(64)),
+                max_clients,
+                sequence: 0,
+            }),
+            protocol_version: MavlinkVersion::V2,
+            id: id.to_string(),
+        })
+    }
+}
+
+pub fn udpins(address: &str) -> io::Result<UdpMultiConnection> {
+    let (addr_str, max_clients) = match address.rsplit_once(':') {
+        Some((left, right)) if right.parse::<usize>().is_ok() => (left, right.parse().unwrap()),
+        _ => (address, DEFAULT_MAX_CLIENTS),
+    };
+    let addr = addr_str
+        .to_socket_addrs()?
+        .next()
+        .expect("udpins: invalid address");
+    let socket = UdpSocket::bind(addr)?;
+    UdpMultiConnection::new(socket, &format!("udpins:{}", address), max_clients)
 }

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -290,12 +290,23 @@ impl<M: Message> MavConnection<M> for UdpMultiConnection {
 ///
 /// When `max_clients` is omitted, defaults to 64.
 pub fn udpins(address: &str) -> io::Result<UdpMultiConnection> {
-    let (addr_str, max_clients) = match address.rsplit_once(':') {
-        Some((left, right)) => match right.parse::<usize>() {
-            Ok(n) => (left, n),
-            Err(_) => (address, DEFAULT_MAX_CLIENTS),
-        },
-        None => (address, DEFAULT_MAX_CLIENTS),
+    // First, try to interpret the entire address as a valid socket address (host:port)
+    let (addr_str, max_clients) = if address
+        .to_socket_addrs()
+        .ok()
+        .and_then(|mut i| i.next())
+        .is_some()
+    {
+        (address, DEFAULT_MAX_CLIENTS)
+    } else {
+        // If that fails, try to split off a trailing max_clients value
+        match address.rsplit_once(':') {
+            Some((left, right)) => match right.parse::<usize>() {
+                Ok(n) => (left, n),
+                Err(_) => (address, DEFAULT_MAX_CLIENTS),
+            },
+            None => (address, DEFAULT_MAX_CLIENTS),
+        }
     };
     let addr = addr_str
         .to_socket_addrs()?

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -219,6 +219,7 @@ pub struct UdpMultiConnection {
 
 impl UdpMultiConnection {
     pub fn new(socket: UdpSocket, id: &str, max_clients: usize) -> io::Result<Self> {
+        let max_clients = max_clients.max(1);
         Ok(Self {
             reader: Mutex::new(UdpRead {
                 socket: socket.try_clone()?,

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -206,6 +206,10 @@ pub(super) struct UdpMultiWrite {
     pub(super) sequence: u8,
 }
 
+/// UDP MAVLink connection supporting multiple clients.
+///
+/// Unlike `UdpConnection` which tracks a single remote endpoint,
+/// this connection broadcasts to all clients that have sent packets.
 pub struct UdpMultiConnection {
     pub(super) reader: Mutex<UdpRead>,
     pub(super) writer: Mutex<UdpMultiWrite>,
@@ -280,10 +284,18 @@ impl<M: Message> MavConnection<M> for UdpMultiConnection {
     }
 }
 
+/// Creates a UDP server connection that broadcasts to multiple clients.
+///
+/// Address format: `host:port` or `host:port:max_clients`
+///
+/// When `max_clients` is omitted, defaults to 64.
 pub fn udpins(address: &str) -> io::Result<UdpMultiConnection> {
     let (addr_str, max_clients) = match address.rsplit_once(':') {
-        Some((left, right)) if right.parse::<usize>().is_ok() => (left, right.parse().unwrap()),
-        _ => (address, DEFAULT_MAX_CLIENTS),
+        Some((left, right)) => match right.parse::<usize>() {
+            Ok(n) => (left, n),
+            Err(_) => (address, DEFAULT_MAX_CLIENTS),
+        },
+        None => (address, DEFAULT_MAX_CLIENTS),
     };
     let addr = addr_str
         .to_socket_addrs()?


### PR DESCRIPTION
New UdpMultiConnection tracks multiple client addresses and broadcasts to all. Oldest client evicted when max reached. If max not specified, defaults to 64.